### PR TITLE
orthographe par Kiko

### DIFF
--- a/doc/fr_FR/addremove.asciidoc
+++ b/doc/fr_FR/addremove.asciidoc
@@ -77,7 +77,7 @@ Si vous avez inclu des modules sans Jeedom (requiert un dongle avec pile comme l
 Si vous n'avez pas l'image ou que Jeedom n'a pas reconnu votre module, ce bouton peut permettre de corriger (sous réserve que l'interview du module soit complète).
 
 [TIP]
-Si sur votre table de routage et/ou sur l'écran de santé Z-Wave vous avez un ou des modules nommés avec leurs *nom générique*, la synchronisation permettra de remédier à cette situation.
+Si sur votre table de routage et/ou sur l'écran de santé Z-Wave vous avez un ou des modules nommés avec leur *nom générique*, la synchronisation permettra de remédier à cette situation.
 
 Le bouton Synchroniser n'est visible qu'en mode expert :
 image:../images/openzwave51.png[]


### PR DESCRIPTION
explication leur prend "s" si plusieurs choses sont possédées Chaque module n'a qu'un seul nom générique