### PR TITLE
Update 134.259.99_zw099_smart.dimmer6.json

### DIFF
--- a/core/config/devices/aeotec_134/134.259.99_zw099_smart.dimmer6.json
+++ b/core/config/devices/aeotec_134/134.259.99_zw099_smart.dimmer6.json
@@ -79,7 +79,7 @@
         "instanceId": 0,
         "value": "data[0].Set(#slider#)",
         "minValue": 0,
-        "maxValue": 100
+        "maxValue": 99
       },
       "template": {
         "dashboard": "light",
@@ -100,7 +100,7 @@
         "instanceId": 0,
         "value": "data[0].val",
         "minValue": 0,
-        "maxValue": 100
+        "maxValue": 99
       }
     },
     {


### PR DESCRIPTION
Ce device ne réagit qu'entre 0 et 99. Avec les paramètres par défaut, si on pousse le slider à 100, rien ne se passe, on doit redescendre à 99 pour obtenir le full brightness.