### PR TITLE
Fixed the battery reporting!!

### DIFF
--- a/core/php/jeeZwave.php
+++ b/core/php/jeeZwave.php
@@ -54,7 +54,7 @@ if (isset($results['devices'])) {
 				foreach ($eqLogic->getCmd('info', $result['instance'] . '.' . $result['CommandClass'] . '.' . $result['index'], null, true) as $cmd) {
 					$cmd->event($result['value']);
 				}
-				if ($result['CommandClass'] == '0x80') {
+				if ($result['CommandClass'] == '0x80' || $result['CommandClass'] == '128') {
 					$eqLogic->batteryStatus($result['value']);
 				}
 			}


### PR DESCRIPTION
On jeedom the page index.php?v=d&p=battery doesn't report the battery status of openzwave. After debuging the openzwave daemon transmit the command class in string that are decimal. 
