### PR TITLE
Add missing parameter to Aeotec Siren Gen5

### DIFF
--- a/resources/openzwaved/config/aeotec/zw080.xml
+++ b/resources/openzwaved/config/aeotec/zw080.xml
@@ -25,6 +25,11 @@ https://aeotec.freshdesk.com/helpdesk/attachments/6009584694
 			<Item label="Sound 5 - Mid Volume" value="1282"/>
 			<Item label="Sound 5 - High Volume" value="1283"/>
 		</Value>
+		<Value type="list" index="38" genre="config" label="Enable/disable the action button" units="" min="0" max="1" value="1" size="1">
+			<Help>Enable/disable to turn off the alarm sound via pressing the Action Button. </Help>
+			<Item label="Disable" value="0" />
+			<Item label="Enable" value="1" />
+		</Value>
 		<Value type="list" index="80" genre="config" label="Send Notifications" units="" min="0" max="1" value="0" size="1">
 			<Help>Enable to send notifications to associated devices (Group 1) when the state of Siren changed</Help>
 			<Item label="Nothing" value="0" />


### PR DESCRIPTION
Add a missing parameter to turn on/off the alarm sound via pressing the Action Button.
Documentation : https://aeotec.freshdesk.com/helpdesk/attachments/6052990312
This change is already merged on https://github.com/OpenZWave/open-zwave/commit/266d3aa45a91d44e16ecf8ab6de296cb4b666651