### PR TITLE
Ajout du support des images au format PNG (extension .png)

### DIFF
--- a/core/class/openzwave.class.php
+++ b/core/class/openzwave.class.php
@@ -491,9 +491,9 @@ class openzwave extends eqLogic {
 
 	public function getImgFilePath() {
 		$id = $this->getConfiguration('manufacturer_id') . '.' . $this->getConfiguration('product_type') . '.' . $this->getConfiguration('product_id');
-		$files = ls(dirname(__FILE__) . '/../config/devices', $id . '_*.jpg', false, array('files', 'quiet'));
+		$files = ls(dirname(__FILE__) . '/../config/devices', $id . '_*.{jpg,png}', false, array('files', 'quiet'));
 		foreach (ls(dirname(__FILE__) . '/../config/devices', '*', false, array('folders', 'quiet')) as $folder) {
-			foreach (ls(dirname(__FILE__) . '/../config/devices/' . $folder, $id . '_*.jpg', false, array('files', 'quiet')) as $file) {
+			foreach (ls(dirname(__FILE__) . '/../config/devices/' . $folder, $id . '_*.{jpg,png}', false, array('files', 'quiet')) as $file) {
 				$files[] = $folder . $file;
 			}
 		}


### PR DESCRIPTION
Ajout du support des images au format PNG (extension .png) en plus des images au format JPG (extension .jpg).

Objectif : permettre d'utiliser des images PNG avec la gestion de la
transparence, sans les renommer en .jpg

Voir https://www.jeedom.com/forum/viewtopic.php?f=34&t=35477&p=605275#p603940

Tristan.