### PR TITLE
[WIP] Allow openzwaved to use IPv6

### DIFF
--- a/core/class/openzwave.class.php
+++ b/core/class/openzwave.class.php
@@ -27,9 +27,9 @@ class openzwave extends eqLogic {
 
 	public static function callOpenzwave($_url) {
 		if (strpos($_url, '?') !== false) {
-			$url = 'http://127.0.0.1:' . config::byKey('port_server', 'openzwave', 8083) . '/' . trim($_url, '/') . '&apikey=' . jeedom::getApiKey('openzwave');
+			$url = 'http://localhost:' . config::byKey('port_server', 'openzwave', 8083) . '/' . trim($_url, '/') . '&apikey=' . jeedom::getApiKey('openzwave');
 		} else {
-			$url = 'http://127.0.0.1:' . config::byKey('port_server', 'openzwave', 8083) . '/' . trim($_url, '/') . '?apikey=' . jeedom::getApiKey('openzwave');
+			$url = 'http://localhost:' . config::byKey('port_server', 'openzwave', 8083) . '/' . trim($_url, '/') . '?apikey=' . jeedom::getApiKey('openzwave');
 		}
 		$ch = curl_init();
 		curl_setopt_array($ch, array(
@@ -277,7 +277,7 @@ class openzwave extends eqLogic {
 		if ($port != 'auto') {
 			$port = jeedom::getUsbMapping($port);
 		}
-		$callback = network::getNetworkAccess('internal', 'proto:127.0.0.1:port:comp') . '/plugins/openzwave/core/php/jeeZwave.php';
+		$callback = network::getNetworkAccess('internal', 'proto:localhost:port:comp') . '/plugins/openzwave/core/php/jeeZwave.php';
 		$port_server = config::byKey('port_server', 'openzwave', 8083);
 		$openzwave_path = dirname(__FILE__) . '/../../resources';
 		$config_path = dirname(__FILE__) . '/../../resources/openzwaved/config';

--- a/resources/openzwaved/ozwave/globals.py
+++ b/resources/openzwaved/ozwave/globals.py
@@ -103,7 +103,7 @@ assumeAwake = False
 disabled_nodes = []
 cycle = 0.3
 socket_host = '127.0.0.1'
-
+socket_host_inet6 = '::1'
 # default_poll_interval = 1800000  # 30 minutes
 default_poll_interval = 300000  # 5 minutes
 maximum_poll_intensity = 1


### PR DESCRIPTION
This PR allows the openzwave daemon and the plugin to communicates through the IPv6 local interface.

It depends on jeedom/core#1071 and will remain with `[WIP]` status until merge.

### Details

* modifies `openzwaved` to listen on IPv6 localhost (`::1`) when IPv6 is available
* plugin queries `openzwaved` on `localhost:<port>` instead of `127.0.0.1:<port>`
* plugin uses new jeedom::getNetworkAccess with `'proto:localhost:port:comp'`
  * see jeedom/core#1071
