### PR TITLE
Add RPI_BOARD_REVISION for Raspberry Pi3

### DIFF
--- a/resources/install_apt.sh
+++ b/resources/install_apt.sh
@@ -137,7 +137,7 @@ if [ -e /dev/ttyAMA0 ];  then
 fi
 
 RPI_BOARD_REVISION=`grep Revision /proc/cpuinfo | cut -d: -f2 | tr -d " "`
-if [[ $RPI_BOARD_REVISION ==  "a02082" || $RPI_BOARD_REVISION == "a22082" ]]
+if [[ $RPI_BOARD_REVISION ==  "a02082" || $RPI_BOARD_REVISION == "a22082" || $RPI_BOARD_REVISION == "a020d3" ]]
 then
    systemctl disable hciuart
    if [[ ! `grep "dtoverlay=pi3-miniuart-bt" /boot/config.txt` ]]


### PR DESCRIPTION
Following this topic: 
https://www.jeedom.com/forum/viewtopic.php?f=34&t=41723&p=679528#p679528

My Raspberry wasn't detected by intastall_apt.sh as a version 3