### PR TITLE
Bad override

### DIFF
--- a/resources/python-openzwave/openzwave/cpp/src/command_classes/ManufacturerProprietary.cpp
+++ b/resources/python-openzwave/openzwave/cpp/src/command_classes/ManufacturerProprietary.cpp
@@ -108,7 +108,7 @@ bool ManufacturerProprietary::HandleMsg
 bool ManufacturerProprietary::RequestValue
 (
     uint32 const _requestFlags,
-    uint16 const _index,
+    uint8 const _index,
     uint8 const _instance,
     Driver::MsgQueue const _queue
 )

--- a/resources/python-openzwave/openzwave/cpp/src/command_classes/ManufacturerProprietary.h
+++ b/resources/python-openzwave/openzwave/cpp/src/command_classes/ManufacturerProprietary.h
@@ -48,7 +48,7 @@ namespace OpenZWave
 		virtual uint8 const GetCommandClassId()const{ return StaticGetCommandClassId(); }
 		virtual string const GetCommandClassName()const{ return StaticGetCommandClassName(); }
 		virtual bool HandleMsg( uint8 const* _data, uint32 const _length, uint32 const _instance = 1 );
-		virtual bool RequestValue( uint32 const _requestFlags, uint16 const _index, uint8 const _instance, Driver::MsgQueue const _queue );
+		virtual bool RequestValue( uint32 const _requestFlags, uint8 const _index, uint8 const _instance, Driver::MsgQueue const _queue );
 		virtual bool SetValue( Value const& _value );
 
 	private:


### PR DESCRIPTION
La signature de la méthode n’est pas la même que celle parente.