### PR TITLE
Register new product type for MCOHome MH7H7-EH

### DIFF
--- a/resources/openzwaved/config/manufacturer_specific.xml
+++ b/resources/openzwaved/config/manufacturer_specific.xml
@@ -934,6 +934,7 @@
     		<Product type="0701" id="5102" name="MH7H Water/Electrical Heating Thermostat" config="mcohome/mh7h.xml"/>
 		<Product type="0702" id="5102" name="MH7H Water/Electrical Heating Thermostat" config="mcohome/mh7h.xml"/>
 		<Product type="0712" id="5102" name="MH7H Water/Electrical Heating Thermostat" config="mcohome/mh7h.xml"/>
+		<Product type="0722" id="5102" name="MH7H Water/Electrical Heating Thermostat" config="mcohome/mh7h.xml"/>
 		<Product type="0732" id="5102" name="MH7H Water/Electrical Heating Thermostat" config="mcohome/mh7h.xml"/>
 		<!--US-->
 		<Product type="5102" id="0103" name="Touch Panel Switch MH-S513" config="mcohome/mhs513.xml"/>


### PR DESCRIPTION
Product type 0722 is yet unknown to jeedom, yet some variants of this heating thermostat using this code are sold by MCO home.