### PR TITLE
Option "socat"

### DIFF
--- a/core/class/openzwave.class.php
+++ b/core/class/openzwave.class.php
@@ -358,7 +358,8 @@ class openzwave extends eqLogic {
 			}
 			system::kill('openzwaved.py');
 			$port = config::byKey('port', 'openzwave');
-			if ($port != 'auto') {
+			$socat = config::byKey('socat', 'openzwave');
+			if ($port != 'auto' && $socat == 0) {
 				system::fuserk(jeedom::getUsbMapping($port));
 			}
 			sleep(1);

--- a/core/i18n/fr_FR.json
+++ b/core/i18n/fr_FR.json
@@ -99,6 +99,7 @@
         "Configs modules": "Configs modules",
         "Démon local": "Démon local",
         "Port clé Z-Wave": "Port clé Z-Wave",
+        "Désactiver la gestion des processus USB (socat)": "Désactiver la gestion des processus USB (socat)",
         "Aucun": "Aucun",
         "Auto": "Auto",
         "Port du Serveur (laisser vide par défault)": "Port du Serveur (laisser vide par défault)",

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -64,6 +64,12 @@ foreach (jeedom::getUsbMapping('', true) as $name => $value) {
 			</div>
 		</div>
 		<div class="form-group">
+			<label class="col-sm-4 control-label">{{Désactiver la gestion des processus USB (socat)}}</label>
+			<div class="col-sm-2">
+				<input type="checkbox" class="configKey" data-l1key="socat"/>
+			</div>
+		</div>
+		<div class="form-group">
 			<label class="col-sm-4 control-label">{{Port du Serveur (laisser vide par défault)}}</label>
 			<div class="col-sm-2">
 				<input class="configKey form-control" data-l1key="port_server" placeholder="8083" />


### PR DESCRIPTION
Bonjour,
j'utilise un Raspberry Pi en tant que "port USB distant" (ser2net sur le Pi + socat sur le Jeedom).
Cela me permet d'avoir les antennes radio placées au centre de mon habitation au lieu de les avoir directement sur le Jeedom qui est au garage dans une baie et nuirait aux performances radio.
Je propose une option "socat" qui évite de tuer le processus "socat" lors du démarrage du démon Z-Wave.
J'utilise cette méthode depuis maintenant plusieurs jours et c'est stable.
A voir si les évolutions à venir (MQTT) ne rendront pas cette façon de faire obsolète, je reste ouvert à la discussion :-)