### PR TITLE
Update max LUX value for this device

### DIFF
--- a/core/config/devices/sensative_410/410.3.10_strips-confort.json
+++ b/core/config/devices/sensative_410/410.3.10_strips-confort.json
@@ -33,7 +33,7 @@
                 "index": 3, 
                 "instance": 1, 
                 "minValue": 0, 
-                "maxValue": 1000
+                "maxValue": 64000
             }, 
             "subtype": "numeric", 
             "display": {


### PR DESCRIPTION
The maximum value for LUX is not 1000 its 64000 according to vendors user manual : https://sensativesupport.zendesk.com/hc/en-us/article_attachments/360026081311/Strips_Comfort_Text_Manual.pdf