### PR TITLE
Fix LIGHT_COLOR state for qubino ZMNHWD1

### DIFF
--- a/core/config/devices/qubino_345/345.1.84_zmnhwd1_flush_rgbw_dimmer.json
+++ b/core/config/devices/qubino_345/345.1.84_zmnhwd1_flush_rgbw_dimmer.json
@@ -174,7 +174,7 @@
             "isVisible": 0, 
             "isHistorized": 0, 
             "configuration": {
-                "class": 38, 
+                "class": 51, 
                 "value": "", 
                 "index": 0, 
                 "instance": 1


### PR DESCRIPTION
Light Color state is currently broken for qubino ZMNHWD1.

LIGHT_COLOR state must be read from class 51 and not 38 (38 is for intensity only).