### PR TITLE
fix Fibaro FGS-224 channel 2 appear to be on instance 3

### DIFF
--- a/core/config/devices/fibaro_271/271.516.4096_fgs224.double.switch.json
+++ b/core/config/devices/fibaro_271/271.516.4096_fgs224.double.switch.json
@@ -107,7 +107,7 @@
             "isVisible": "1"
         }, 
         {
-            "name": "On 2 ", 
+            "name": "On 2",
             "type": "action", 
             "subtype": "other", 
             "isVisible": 1, 
@@ -118,7 +118,7 @@
             "configuration": {
                 "class": 37, 
                 "value": "type=setvalue&value=255", 
-                "instance": 2, 
+                "instance": 3,
                 "index": 0
             }, 
             "template": {
@@ -127,7 +127,7 @@
             }
         }, 
         {
-            "name": "Off 2 ", 
+            "name": "Off 2",
             "type": "action", 
             "subtype": "other", 
             "isVisible": 1, 
@@ -138,7 +138,7 @@
             "configuration": {
                 "class": 37, 
                 "value": "type=setvalue&value=0", 
-                "instance": 2, 
+                "instance": 3,
                 "index": 0
             }, 
             "template": {
@@ -157,7 +157,7 @@
             "configuration": {
                 "class": 37, 
                 "value": "", 
-                "instance": 2, 
+                "instance": 3,
                 "index": 0
             }
         }, 
@@ -172,7 +172,7 @@
                 "value": "", 
                 "maxValue": 2500, 
                 "minValue": 0, 
-                "instance": 2, 
+                "instance": 3,
                 "index": 8
             }, 
             "template": {
@@ -194,7 +194,7 @@
             "configuration": {
                 "class": 50, 
                 "value": "", 
-                "instance": 2, 
+                "instance": 3,
                 "index": 0
             }, 
             "template": {


### PR DESCRIPTION
Hi,

Both Channel 1 and 2 are triggering the same light. After testing, channel 2 appear to be on instance 3.

By the way, CONSUMPTION and POWER are not working on both channels. I can't find any technical documentation by Fibaro to fix it.

Boris.