### PR TITLE
max value at  2000 Lux.

### DIFF
--- a/core/config/devices/steinel_625/625.1.6771_xled.home2.json
+++ b/core/config/devices/steinel_625/625.1.6771_xled.home2.json
@@ -96,7 +96,7 @@
                 "index": 3,
                 "instance": 1,
                 "minValue": 0,
-                "maxValue": 40000
+                "maxValue": 2000
             },
             "subtype": "numeric",
             "display": {


### PR DESCRIPTION
documentation :
2000 - is used as daylight (always night mode). 0 - run Learn ambient light sequence. 2-1999 lux.