### PR TITLE
Fix commands heiman smoke sensor

### DIFF
--- a/core/config/devices/heiman_608/608.32770.4096_dx1saz_smoke_sensor.json
+++ b/core/config/devices/heiman_608/608.32770.4096_dx1saz_smoke_sensor.json
@@ -1,31 +1,31 @@
 {
-    "name": "Smart Smoke Sensor (HS1SA-Z)", 
-    "type": "Fumée", 
-    "comlink": "", 
-    "remark": "", 
-    "imglink": "heiman.hs1saz", 
+    "name": "Smart Smoke Sensor (HS1SA-Z)",
+    "type": "Fumée",
+    "comlink": "",
+    "remark": "",
+    "imglink": "heiman.hs1saz",
     "configuration": {
         "battery_type": "1x3V CR123A"
-    }, 
+    },
     "commands": [
         {
-            "name": "Fumées", 
-            "type": "info", 
-            "isVisible": 1, 
-            "isHistorized": 0, 
+            "name": "Fumées",
+            "type": "info",
+            "isVisible": 1,
+            "isHistorized": 0,
             "configuration": {
-                "class": 48, 
-                "value": "", 
-                "index": 0, 
-                "instance": 1
-            }, 
-            "subtype": "binary", 
+                "class": 113,
+                "value": "",
+                "index": 1,
+                "instance": 4
+            },
+            "subtype": "binary",
             "display": {
-                "invertBinary": "1", 
+                "invertBinary": "1",
                 "generic_type": "SMOKE"
-            }, 
+            },
             "template": {
-                "dashboard": "feu", 
+                "dashboard": "feu",
                 "mobile": "feu"
             }
         }

--- a/core/config/devices/heiman_608/608.32770.4096_dx1saz_smoke_sensor.json
+++ b/core/config/devices/heiman_608/608.32770.4096_dx1saz_smoke_sensor.json
@@ -16,8 +16,8 @@
             "configuration": {
                 "class": 113,
                 "value": "",
-                "index": 1,
-                "instance": 4
+                "index": 4,
+                "instance": 1
             },
             "subtype": "binary",
             "display": {


### PR DESCRIPTION
Les modules Smoke sensor Heiman HS1SA-Z actuels (depuis au moins 1 an), ayant un nouveau firmware, notifie la détection de fumée via la valeur "smoke" et plus avec la valeur "sensor".
Plus de détails ici https://community.jeedom.com/t/smoke-sensor-heiman-hs1sa-z-aucune-commande-creee/9752/22

La conséquence c'est que le module une fois inclus sera silencieux sous jeedom, pas terrible pour un détecteur de fumée...