### PR TITLE
Possibility for server to listen on a different host

### DIFF
--- a/core/class/openzwave.class.php
+++ b/core/class/openzwave.class.php
@@ -35,9 +35,9 @@ class openzwave extends eqLogic {
 	
 	public static function callOpenzwave($_url,$_timeout = null) {
 		if (strpos($_url, '?') !== false) {
-			$url = 'http://127.0.0.1:' . config::byKey('port_server', 'openzwave', 8083) . '/' . trim($_url, '/') . '&apikey=' . jeedom::getApiKey('openzwave');
+			$url = 'http://'. config::byKey('host_server', 'openzwave', '127.0.0.1') . ':' . config::byKey('port_server', 'openzwave', 8083) . '/' . trim($_url, '/') . '&apikey=' . jeedom::getApiKey('openzwave');
 		} else {
-			$url = 'http://127.0.0.1:' . config::byKey('port_server', 'openzwave', 8083) . '/' . trim($_url, '/') . '?apikey=' . jeedom::getApiKey('openzwave');
+			$url = 'http://'. config::byKey('host_server', 'openzwave', '127.0.0.1') . ':' . config::byKey('port_server', 'openzwave', 8083) . '/' . trim($_url, '/') . '?apikey=' . jeedom::getApiKey('openzwave');
 		}
 		$ch = curl_init();
 		curl_setopt_array($ch, array(
@@ -299,6 +299,7 @@ class openzwave extends eqLogic {
 			return false;
 		}
 		$callback = network::getNetworkAccess('internal', 'proto:127.0.0.1:port:comp') . '/plugins/openzwave/core/php/jeeZwave.php';
+		$host_server = config::byKey('host_server', 'openzwave', '127.0.0.1');
 		$port_server = config::byKey('port_server', 'openzwave', 8083);
 		$openzwave_path = dirname(__FILE__) . '/../../resources';
 		$config_path = dirname(__FILE__) . '/../../resources/openzwaved/config';
@@ -322,6 +323,7 @@ class openzwave extends eqLogic {
 		$cmd = '/usr/bin/python ' . $openzwave_path . '/openzwaved/openzwaved.py ';
 		$cmd .= ' --device ' . $port;
 		$cmd .= ' --loglevel ' . log::convertLogLevel(log::getLogLevel('openzwave'));
+		$cmd .= ' --host ' . $host_server;
 		$cmd .= ' --port ' . $port_server;
 		$cmd .= ' --config_folder ' . $config_path;
 		$cmd .= ' --data_folder ' . $data_path;

--- a/core/config/openzwave.config.ini
+++ b/core/config/openzwave.config.ini
@@ -6,4 +6,5 @@ auto_updateConf = 1
 suppress_refresh = 0
 assume_awake = 0
 cycle = 0.3
+host_server=127.0.0.1
 port_server=8083

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -81,6 +81,9 @@ if (!isConnect('admin')) {
 				<sup><i class="fas fa-question-circle tooltips" title="{{Permet de modifier le port de communication interne du démon. Réservé aux utilisateurs avancés}}"></i></sup>
 			</label>
 			<div class="col-md-6">
+				<input class="configKey form-control" data-l1key="host_server" placeholder="127.0.0.1" />
+			</div>
+			<div class="col-md-6">
 				<input class="configKey form-control" data-l1key="port_server" placeholder="8083" />
 			</div>
 		</div>

--- a/resources/openzwaved/openzwaved.py
+++ b/resources/openzwaved/openzwaved.py
@@ -30,6 +30,7 @@ os.environ['PYTHON_EGG_CACHE'] = '/tmp/python-openzwave-eggs'
 
 parser = argparse.ArgumentParser(description='Ozw Daemon for Jeedom plugin')
 parser.add_argument("--device", help="Device", type=str)
+parser.add_argument("--host", help="Host for OZW server", type=str)
 parser.add_argument("--port", help="Port for OZW server", type=str)
 parser.add_argument("--loglevel", help="Log Level for the daemon", type=str)
 parser.add_argument("--config_folder", help="Read or Write", type=str)
@@ -44,6 +45,8 @@ args = parser.parse_args()
 
 if args.device:
 	globals.device = args.device
+if args.host:
+	globals.socket_host = args.host
 if args.port:
 	globals.port_server = args.port
 if args.loglevel:

--- a/resources/openzwaved/ozwave/server_utils.py
+++ b/resources/openzwaved/ozwave/server_utils.py
@@ -40,7 +40,7 @@ def check_start_server():
 
 	logging.info("Check if the port REST server available")
 	_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-	port_available = _sock.connect_ex(('127.0.0.1', int(globals.port_server)))
+	port_available = _sock.connect_ex((globals.socket_host, int(globals.port_server)))
 	if port_available == 0:
 		logging.error('The port %s is already in use. Please check your Z-Wave (openzwave) configuration plugin page' % (
 		globals.port_server,), 'error')


### PR DESCRIPTION
Dans mon installation (non standard…) jeedom est découpé en plusieurs containers docker (db, redis, cron, fpm, front web server, openzwave server, …). Les mises à jour sont faites par regénération des images (inspiré des images qu’on peut trouver dans le projet nextcloud). Je n’ai presque plus de bugs de mises à jour depuis cette config, et les retour en arrière sont très rapides en cas de problème.

Jusqu’ici openzwave tourne dans le même namespace (pid, network) que cron et fpm. L’objectif de ce pull request est de pouvoir les séparer, et de communiquer via un bridge interne, donc pas sur 127.0.0.1