### PR TITLE
Fix serialization error (reproducible with Aeotec ZW164 Siren 6 ZWAVE PLUS )

### DIFF
--- a/resources/openzwaved/ozwave/serialization.py
+++ b/resources/openzwaved/ozwave/serialization.py
@@ -190,7 +190,11 @@ def serialize_node_to_json(node_id):
 			index2 = 0
 		pending_state = None
 		expected_data = None
-		data_items = utils.concatenate_list(my_value.data_items)
+		try:
+			data_items = utils.concatenate_list(my_value.data_items)
+		except Exception, exception:
+			data_items = exception.message
+			logging.error('Value data_items contains unsupported data: %s' % (str(exception),))
 		if my_value.id_on_network in globals.pending_configurations:
 			pending = globals.pending_configurations[my_value.id_on_network]
 			if pending is not None:


### PR DESCRIPTION
Trying to integrate an Aeotec ZW164 Siren 6 ZWAVE PLUS 

- Identifiant du fabricant : 881 [0x0371] Type de produit : 3 [0x0003] 
- Identifiant du produit : 164 [0x00a4]

It looks like the openzwave library is unable to parse the content of a specific field and the jeedom's openzwave plugin does not take care of an upstream invalid parsing.

The purpose of this PR is to allow the plugin to continue its normal process even after a such error.

![image](https://user-images.githubusercontent.com/22446243/191962842-e7f6380f-d32c-476d-8ef7-766d3796f61f.png)

As a consequence with this fix, the list is empty (should not ?)
![image](https://user-images.githubusercontent.com/22446243/191962945-442dc017-21dd-4270-981d-ac371d25416c.png)

Please note that I'm not able to play any sound from the sound list of the alarm plugin on this device.
