### PR TITLE
Update ZMNHTDx.xml

### DIFF
--- a/resources/openzwaved/config/qubino/ZMNHTDx.xml
+++ b/resources/openzwaved/config/qubino/ZMNHTDx.xml
@@ -93,8 +93,8 @@ ZMNHTD5 916,0 MHz
 				Default value 0
 			</Help>
 			<Item label="Endpoints IR external relay and External relay disabled" value="0"/>
-			<Item label="Endpoints IR external relay disabled, External relay enabled" value="1"/>
-			<Item label="Endpoints IR external relay enabled, External relay disabled" value="2"/>
+			<Item label="Endpoints IR external relay enabled, External relay disabled" value="1"/>
+			<Item label="Endpoints IR external relay disabled, External relay enabled" value="2"/>
 			<Item label="Endpoints IR external relay and External relay enabled" value="3"/>
 		</Value>
 


### PR DESCRIPTION
Permutation of lines 96 and 97 to reflect the official documentation values: https://qubino.com/manuals/Smart_Meter.pdf page 43. Validated on my configuration using a  IKA232-20 on the external relay output line. Fully working.